### PR TITLE
feat: implement MenuItemReview index page with tests and stories

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -3,6 +3,7 @@ const config = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     "@storybook/addon-links",
+    "msw-storybook-addon",
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/frontend/.storybook/preview.jsx
+++ b/frontend/.storybook/preview.jsx
@@ -11,21 +11,26 @@ initialize({
   onUnhandledRequest: "bypass",
 });
 
-const queryClient = new QueryClient();
-
 // Per https://storybook.js.org/docs/react/writing-stories/decorators#context-for-mocking
-// Here, we provide the context needed for some of the components,
-// e.g. the ones that rely on currentUser
-
+// Fresh client per story: avoids stale React Query errors and disables retries (each
+// retry re-toasts from useBackend on failure).
 export const decorators = [
-  (Story) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <ToastContainer />
-        <Story />
-      </MemoryRouter>
-    </QueryClientProvider>
-  ),
+  (Story) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ToastContainer />
+          <Story />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  },
 ];
 
 /** @type { import('@storybook/react').Preview } */

--- a/frontend/.storybook/preview.jsx
+++ b/frontend/.storybook/preview.jsx
@@ -5,6 +5,11 @@ import "react-toastify/dist/ReactToastify.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import { ToastContainer } from "react-toastify";
+import { initialize, mswLoader } from "msw-storybook-addon";
+
+initialize({
+  onUnhandledRequest: "bypass",
+});
 
 const queryClient = new QueryClient();
 
@@ -20,7 +25,7 @@ export const decorators = [
         <Story />
       </MemoryRouter>
     </QueryClientProvider>
-  )
+  ),
 ];
 
 /** @type { import('@storybook/react').Preview } */
@@ -33,6 +38,7 @@ const preview = {
       },
     },
   },
+  loaders: [mswLoader],
 };
 
 export default preview;

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function MenuItemReviewIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: reviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/MenuItemReview/all"],
+    { method: "GET", url: "/api/MenuItemReview/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreview/create"
+          style={{ float: "right" }}
+        >
+          Create Menu Item Review
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/menuitemreview/create">Create</a>
-        </p>
-        <p>
-          <a href="/menuitemreview/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Menu Item Reviews</h1>
+        <MenuItemReviewTable reviews={reviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -34,7 +34,8 @@ ThreeItemsAdminUser.args = {
 };
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.delete("/api/MenuItemReview", () => {
       return HttpResponse.json(
         { message: "MenuItemReview deleted successfully" },
@@ -42,4 +43,5 @@ ThreeItemsAdminUser.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -36,12 +36,12 @@ ThreeItemsAdminUser.args = {
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.delete("/api/MenuItemReview", () => {
-      return HttpResponse.json(
-        { message: "MenuItemReview deleted successfully" },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.delete("/api/MenuItemReview", () => {
+        return HttpResponse.json(
+          { message: "MenuItemReview deleted successfully" },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.jsx
@@ -36,7 +36,7 @@ ThreeItemsAdminUser.args = {
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-      http.delete("/api/MenuItemReview", () => {
+      http.delete("*/api/MenuItemReview", () => {
         return HttpResponse.json(
           { message: "MenuItemReview deleted successfully" },
           { status: 200 },

--- a/frontend/src/stories/components/Restaurants/RestaurantTable.stories.jsx
+++ b/frontend/src/stories/components/Restaurants/RestaurantTable.stories.jsx
@@ -36,12 +36,12 @@ ThreeItemsAdminUser.args = {
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.delete("/api/restaurants", () => {
-      return HttpResponse.json(
-        { message: "Restaurant deleted successfully" },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.delete("/api/restaurants", () => {
+        return HttpResponse.json(
+          { message: "Restaurant deleted successfully" },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/components/Restaurants/RestaurantTable.stories.jsx
+++ b/frontend/src/stories/components/Restaurants/RestaurantTable.stories.jsx
@@ -34,7 +34,8 @@ ThreeItemsAdminUser.args = {
 };
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.delete("/api/restaurants", () => {
       return HttpResponse.json(
         { message: "Restaurant deleted successfully" },
@@ -42,4 +43,5 @@ ThreeItemsAdminUser.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/components/UCSBDates/UCSBDatesTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBDates/UCSBDatesTable.stories.jsx
@@ -33,9 +33,11 @@ ThreeItemsAdminUser.args = {
 };
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.delete("/api/ucsbdates", () => {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/components/UCSBDates/UCSBDatesTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBDates/UCSBDatesTable.stories.jsx
@@ -35,9 +35,9 @@ ThreeItemsAdminUser.args = {
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.delete("/api/ucsbdates", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.delete("/api/ucsbdates", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/components/Urls/UrlTable.stories.jsx
+++ b/frontend/src/stories/components/Urls/UrlTable.stories.jsx
@@ -36,12 +36,12 @@ FourItemsAdminUser.args = {
 FourItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.delete("/api/restaurants", () => {
-      return HttpResponse.json(
-        { message: "Url deleted successfully" },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.delete("/api/restaurants", () => {
+        return HttpResponse.json(
+          { message: "Url deleted successfully" },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/components/Urls/UrlTable.stories.jsx
+++ b/frontend/src/stories/components/Urls/UrlTable.stories.jsx
@@ -34,7 +34,8 @@ FourItemsAdminUser.args = {
 };
 
 FourItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.delete("/api/restaurants", () => {
       return HttpResponse.json(
         { message: "Url deleted successfully" },
@@ -42,4 +43,5 @@ FourItemsAdminUser.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
@@ -16,29 +16,29 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.post("/api/MenuItemReview/post", () => {
-      return HttpResponse.json(
-        {
-          id: 1,
-          itemId: 101,
-          reviewerEmail: "cgaucho@ucsb.edu",
-          stars: 5,
-          dateReviewed: "2022-01-02T12:00:00",
-          comments: "Best pizza at Carrillo",
-        },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.post("/api/MenuItemReview/post", () => {
+        return HttpResponse.json(
+          {
+            id: 1,
+            itemId: 101,
+            reviewerEmail: "cgaucho@ucsb.edu",
+            stars: 5,
+            dateReviewed: "2022-01-02T12:00:00",
+            comments: "Best pizza at Carrillo",
+          },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
@@ -14,7 +14,8 @@ const Template = () => <MenuItemReviewCreatePage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -39,4 +40,5 @@ Default.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.jsx
@@ -16,17 +16,17 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-      http.get("/api/currentUser", () => {
+      http.get("*/api/currentUser", () => {
         return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
           status: 200,
         });
       }),
-      http.get("/api/systemInfo", () => {
+      http.get("*/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither, {
           status: 200,
         });
       }),
-      http.post("/api/MenuItemReview/post", () => {
+      http.post("*/api/MenuItemReview/post", () => {
         return HttpResponse.json(
           {
             id: 1,

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -15,7 +15,8 @@ const Template = () => <MenuItemReviewIndexPage storybook={true} />;
 
 export const Empty = Template.bind({});
 Empty.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -30,12 +31,14 @@ Empty.parameters = {
       return HttpResponse.json([], { status: 200 });
     }),
   ],
+  },
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly);
     }),
@@ -46,12 +49,14 @@ ThreeItemsOrdinaryUser.parameters = {
       return HttpResponse.json(menuItemReviewFixtures.threeReviews);
     }),
   ],
+  },
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.adminUser);
     }),
@@ -68,4 +73,5 @@ ThreeItemsAdminUser.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/MenuItemReview/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/MenuItemReview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/MenuItemReview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+    }),
+    http.delete("/api/MenuItemReview", () => {
+      return HttpResponse.json(
+        { message: "MenuItemReview with id 1 deleted" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -17,17 +17,17 @@ export const Empty = Template.bind({});
 Empty.parameters = {
   msw: {
     handlers: [
-      http.get("/api/currentUser", () => {
+      http.get("*/api/currentUser", () => {
         return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
           status: 200,
         });
       }),
-      http.get("/api/systemInfo", () => {
+      http.get("*/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither, {
           status: 200,
         });
       }),
-      http.get("/api/MenuItemReview/all", () => {
+      http.get("*/api/MenuItemReview/all", () => {
         return HttpResponse.json([], { status: 200 });
       }),
     ],
@@ -39,13 +39,13 @@ export const ThreeItemsOrdinaryUser = Template.bind({});
 ThreeItemsOrdinaryUser.parameters = {
   msw: {
     handlers: [
-      http.get("/api/currentUser", () => {
+      http.get("*/api/currentUser", () => {
         return HttpResponse.json(apiCurrentUserFixtures.userOnly);
       }),
-      http.get("/api/systemInfo", () => {
+      http.get("*/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither);
       }),
-      http.get("/api/MenuItemReview/all", () => {
+      http.get("*/api/MenuItemReview/all", () => {
         return HttpResponse.json(menuItemReviewFixtures.threeReviews);
       }),
     ],
@@ -57,16 +57,16 @@ export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-      http.get("/api/currentUser", () => {
+      http.get("*/api/currentUser", () => {
         return HttpResponse.json(apiCurrentUserFixtures.adminUser);
       }),
-      http.get("/api/systemInfo", () => {
+      http.get("*/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither);
       }),
-      http.get("/api/MenuItemReview/all", () => {
+      http.get("*/api/MenuItemReview/all", () => {
         return HttpResponse.json(menuItemReviewFixtures.threeReviews);
       }),
-      http.delete("/api/MenuItemReview", () => {
+      http.delete("*/api/MenuItemReview", () => {
         return HttpResponse.json(
           { message: "MenuItemReview with id 1 deleted" },
           { status: 200 },

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -17,20 +17,20 @@ export const Empty = Template.bind({});
 Empty.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.get("/api/MenuItemReview/all", () => {
-      return HttpResponse.json([], { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/MenuItemReview/all", () => {
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
   },
 };
 
@@ -39,16 +39,16 @@ export const ThreeItemsOrdinaryUser = Template.bind({});
 ThreeItemsOrdinaryUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/MenuItemReview/all", () => {
-      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/MenuItemReview/all", () => {
+        return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+      }),
+    ],
   },
 };
 
@@ -57,21 +57,21 @@ export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/MenuItemReview/all", () => {
-      return HttpResponse.json(menuItemReviewFixtures.threeReviews);
-    }),
-    http.delete("/api/MenuItemReview", () => {
-      return HttpResponse.json(
-        { message: "MenuItemReview with id 1 deleted" },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/MenuItemReview/all", () => {
+        return HttpResponse.json(menuItemReviewFixtures.threeReviews);
+      }),
+      http.delete("/api/MenuItemReview", () => {
+        return HttpResponse.json(
+          { message: "MenuItemReview with id 1 deleted" },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantCreatePage.stories.jsx
@@ -16,19 +16,19 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.post("/api/restaurants/post", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.post("/api/restaurants/post", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantCreatePage.stories.jsx
@@ -14,7 +14,8 @@ const Template = () => <RestaurantCreatePage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -29,4 +30,5 @@ Default.parameters = {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantEditPage.stories.jsx
@@ -17,28 +17,28 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.get("/api/restaurants", () => {
-      return HttpResponse.json(restaurantFixtures.threeRestaurants[0], {
-        status: 200,
-      });
-    }),
-    http.put("/api/restaurants", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-    http.put("/api/restaurants", (req) => {
-      window.alert("PUT: " + req.url + " and body: " + req.body);
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/restaurants", () => {
+        return HttpResponse.json(restaurantFixtures.threeRestaurants[0], {
+          status: 200,
+        });
+      }),
+      http.put("/api/restaurants", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+      http.put("/api/restaurants", (req) => {
+        window.alert("PUT: " + req.url + " and body: " + req.body);
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantEditPage.stories.jsx
@@ -15,7 +15,8 @@ const Template = () => <RestaurantEditPage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -39,4 +40,5 @@ Default.parameters = {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantIndexPage.stories.jsx
@@ -17,20 +17,20 @@ export const Empty = Template.bind({});
 Empty.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.get("/api/restaurants/all", () => {
-      return HttpResponse.json([], { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/restaurants/all", () => {
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
   },
 };
 
@@ -39,16 +39,16 @@ export const ThreeItemsOrdinaryUser = Template.bind({});
 ThreeItemsOrdinaryUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/restaurants/all", () => {
-      return HttpResponse.json(restaurantFixtures.threeRestaurants);
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/restaurants/all", () => {
+        return HttpResponse.json(restaurantFixtures.threeRestaurants);
+      }),
+    ],
   },
 };
 
@@ -57,21 +57,21 @@ export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/restaurants/all", () => {
-      return HttpResponse.json(restaurantFixtures.threeRestaurants);
-    }),
-    http.delete("/api/restaurants", () => {
-      return HttpResponse.json(
-        { message: "Restaurant deleted successfully" },
-        { status: 200 },
-      );
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/restaurants/all", () => {
+        return HttpResponse.json(restaurantFixtures.threeRestaurants);
+      }),
+      http.delete("/api/restaurants", () => {
+        return HttpResponse.json(
+          { message: "Restaurant deleted successfully" },
+          { status: 200 },
+        );
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/Restaurants/RestaurantIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/Restaurants/RestaurantIndexPage.stories.jsx
@@ -15,7 +15,8 @@ const Template = () => <RestaurantIndexPage storybook={true} />;
 
 export const Empty = Template.bind({});
 Empty.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -30,12 +31,14 @@ Empty.parameters = {
       return HttpResponse.json([], { status: 200 });
     }),
   ],
+  },
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly);
     }),
@@ -46,12 +49,14 @@ ThreeItemsOrdinaryUser.parameters = {
       return HttpResponse.json(restaurantFixtures.threeRestaurants);
     }),
   ],
+  },
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.adminUser);
     }),
@@ -68,4 +73,5 @@ ThreeItemsAdminUser.parameters = {
       );
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.jsx
@@ -14,7 +14,8 @@ const Template = () => <UCSBDatesCreatePage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -29,4 +30,5 @@ Default.parameters = {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesCreatePage.stories.jsx
@@ -16,19 +16,19 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.post("/api/ucsbdates/post", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.post("/api/ucsbdates/post", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.jsx
@@ -15,7 +15,8 @@ const Template = () => <UCSBDatesEditPage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -35,4 +36,5 @@ Default.parameters = {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesEditPage.stories.jsx
@@ -17,24 +17,24 @@ export const Default = Template.bind({});
 Default.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.get("/api/ucsbdates", () => {
-      return HttpResponse.json(ucsbDatesFixtures.threeDates[0], {
-        status: 200,
-      });
-    }),
-    http.put("/api/ucsbdates", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/ucsbdates", () => {
+        return HttpResponse.json(ucsbDatesFixtures.threeDates[0], {
+          status: 200,
+        });
+      }),
+      http.put("/api/ucsbdates", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.jsx
@@ -15,7 +15,8 @@ const Template = () => <UCSBDatesIndexPage storybook={true} />;
 
 export const Empty = Template.bind({});
 Empty.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
         status: 200,
@@ -30,12 +31,14 @@ Empty.parameters = {
       return HttpResponse.json([], { status: 200 });
     }),
   ],
+  },
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.userOnly);
     }),
@@ -46,12 +49,14 @@ ThreeItemsOrdinaryUser.parameters = {
       return HttpResponse.json(ucsbDatesFixtures.threeDates);
     }),
   ],
+  },
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 
 ThreeItemsAdminUser.parameters = {
-  msw: [
+  msw: {
+    handlers: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.adminUser);
     }),
@@ -65,4 +70,5 @@ ThreeItemsAdminUser.parameters = {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],
+  },
 };

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.jsx
@@ -17,20 +17,20 @@ export const Empty = Template.bind({});
 Empty.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
-        status: 200,
-      });
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither, {
-        status: 200,
-      });
-    }),
-    http.get("/api/ucsbdates/all", () => {
-      return HttpResponse.json([], { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/ucsbdates/all", () => {
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
   },
 };
 
@@ -39,16 +39,16 @@ export const ThreeItemsOrdinaryUser = Template.bind({});
 ThreeItemsOrdinaryUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/ucsbdates/all", () => {
-      return HttpResponse.json(ucsbDatesFixtures.threeDates);
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/ucsbdates/all", () => {
+        return HttpResponse.json(ucsbDatesFixtures.threeDates);
+      }),
+    ],
   },
 };
 
@@ -57,18 +57,18 @@ export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.parameters = {
   msw: {
     handlers: [
-    http.get("/api/currentUser", () => {
-      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
-    }),
-    http.get("/api/systemInfo", () => {
-      return HttpResponse.json(systemInfoFixtures.showingNeither);
-    }),
-    http.get("/api/ucsbdates/all", () => {
-      return HttpResponse.json(ucsbDatesFixtures.threeDates);
-    }),
-    http.delete("/api/ucsbdates", () => {
-      return HttpResponse.json({}, { status: 200 });
-    }),
-  ],
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/ucsbdates/all", () => {
+        return HttpResponse.json(ucsbDatesFixtures.threeDates);
+      }),
+      http.delete("/api/ucsbdates", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
   },
 };

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
@@ -1,15 +1,37 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
 describe("MenuItemReviewIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "MenuItemReviewTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,9 +44,21 @@ describe("MenuItemReviewIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/MenuItemReview/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -34,12 +68,159 @@ describe("MenuItemReviewIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create Menu Item Review/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Menu Item Review/);
+    expect(button).toHaveAttribute("href", "/menuitemreview/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three reviews correctly for regular user", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/MenuItemReview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
 
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByText("Create Menu Item Review"),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-reviewerEmail`),
+    ).toHaveTextContent("cgaucho@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-comments`),
+    ).toHaveTextContent("Best pizza at Carrillo");
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/MenuItemReview/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/MenuItemReview/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+
+    axiosMock
+      .onGet("/api/MenuItemReview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+    axiosMock
+      .onDelete("/api/MenuItemReview")
+      .reply(200, "MenuItemReview with id 1 deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("MenuItemReview with id 1 deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/MenuItemReview");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+
+  test("admin edit button navigates to edit page for that record", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/MenuItemReview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith("/menuitemreview/edit/1");
+    });
   });
 });


### PR DESCRIPTION
- Load all reviews from GET /api/MenuItemReview/all via useBackend
- Admin-only Create button; table shows edit/delete only for ROLE_ADMIN
- Tests mirror Restaurant/UCSBDates index patterns plus admin edit navigation
- Add Storybook stories with MSW for empty, user, and admin views


Storybook: https://69f2f3fdc277d896027e091a-qhchjpcitv.chromatic.com/?path=/story/pages-menuitemreview-menuitemreviewindexpage--three-items-admin-user

Screenshot: 
<img width="1132" height="318" alt="Screenshot 2026-04-30 at 5 58 38 PM" src="https://github.com/user-attachments/assets/1e3b4923-702e-4c52-92a3-5a3df7bd8cc9" />


closes #35 

