### PR TITLE
Pc rr index

### DIFF
--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -1,10 +1,46 @@
 import React from "react";
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { hasRole } from "main/utils/useCurrentUser";
+import { toast } from "react-toastify";
+import { useBackendMutation } from "main/utils/useBackend";
+import { useNavigate } from "react-router";
 
 export default function RecommendationRequestTable({
   recommendationRequests,
+  currentUser,
   testIdPrefix = "RecommendationRequestTable",
 }) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/recommendationrequest/edit/${cell.row.original.id}`);
+  };
+
+  const cellToAxiosParamsDelete = (cell) => ({
+    url: "/api/RecommendationRequest",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  });
+
+  const onDeleteSuccess = (message) => {
+    toast(message);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/RecommendationRequest/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : hard to test mutation internals here
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
   const columns = [
     {
       header: "id",
@@ -35,6 +71,13 @@ export default function RecommendationRequestTable({
       accessorKey: "done",
     },
   ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
 
   return React.createElement(OurTable, {
     data: recommendationRequests,

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,33 +1,51 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { useBackend } from "main/utils/useBackend";
+import { hasRole, useCurrentUser } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function RecommendationRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: recommendationRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/RecommendationRequest/all"],
+    { method: "GET", url: "/api/RecommendationRequest/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return React.createElement(
+        Button,
+        {
+          variant: "primary",
+          href: "/recommendationrequest/create",
+          style: { float: "right" },
+        },
+        "Create RecommendationRequest",
+      );
+    }
+  };
+
   return React.createElement(
     BasicLayout,
     null,
     React.createElement(
       "div",
       { className: "pt-2" },
-      React.createElement("h1", null, "Index page not yet implemented"),
-      React.createElement(
-        "p",
-        null,
-        React.createElement(
-          "a",
-          { href: "/recommendationrequest/create" },
-          "Create",
-        ),
-      ),
-      React.createElement(
-        "p",
-        null,
-        React.createElement(
-          "a",
-          { href: "/recommendationrequest/edit/1" },
-          "Edit",
-        ),
-      ),
+      createButton(),
+      React.createElement("h1", null, "RecommendationRequests"),
+      React.createElement(RecommendationRequestTable, {
+        recommendationRequests,
+        currentUser,
+      }),
     ),
   );
 }

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestIndexPage",
+  component: RecommendationRequestIndexPage,
+};
+
+const Template = () => React.createElement(RecommendationRequestIndexPage);
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/RecommendationRequest/all", () => {
+        return HttpResponse.json([], { status: 200 });
+      }),
+    ],
+  },
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/RecommendationRequest/all", () => {
+        return HttpResponse.json(
+          recommendationRequestFixtures.threeRecommendationRequests,
+        );
+      }),
+    ],
+  },
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/RecommendationRequest/all", () => {
+        return HttpResponse.json(
+          recommendationRequestFixtures.threeRecommendationRequests,
+        );
+      }),
+      http.delete("/api/RecommendationRequest", () => {
+        return HttpResponse.json("RecommendationRequest deleted successfully", {
+          status: 200,
+        });
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -1,8 +1,20 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
 
 import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
 import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 describe("RecommendationRequestTable tests", () => {
   const h = React.createElement;
@@ -28,8 +40,30 @@ describe("RecommendationRequestTable tests", () => {
     "done",
   ];
 
+  const renderTable = (props) => {
+    const queryClient = new QueryClient();
+    render(
+      h(
+        QueryClientProvider,
+        { client: queryClient },
+        h(
+          MemoryRouter,
+          null,
+          h(RecommendationRequestTable, {
+            recommendationRequests: [],
+            ...props,
+          }),
+        ),
+      ),
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test("renders empty table correctly", () => {
-    render(h(RecommendationRequestTable, { recommendationRequests: [] }));
+    renderTable({ recommendationRequests: [] });
 
     expectedHeaders.forEach((headerText) => {
       expect(screen.getByText(headerText)).toBeInTheDocument();
@@ -43,12 +77,10 @@ describe("RecommendationRequestTable tests", () => {
   });
 
   test("has the expected column headers and content", () => {
-    render(
-      h(RecommendationRequestTable, {
-        recommendationRequests:
-          recommendationRequestFixtures.threeRecommendationRequests,
-      }),
-    );
+    renderTable({
+      recommendationRequests:
+        recommendationRequestFixtures.threeRecommendationRequests,
+    });
 
     expectedHeaders.forEach((headerText) => {
       expect(screen.getByText(headerText)).toBeInTheDocument();
@@ -96,16 +128,53 @@ describe("RecommendationRequestTable tests", () => {
   test("supports a custom testIdPrefix", () => {
     const customTestId = "CustomRecommendationRequestTable";
 
-    render(
-      h(RecommendationRequestTable, {
-        recommendationRequests:
-          recommendationRequestFixtures.threeRecommendationRequests,
-        testIdPrefix: customTestId,
-      }),
-    );
+    renderTable({
+      recommendationRequests:
+        recommendationRequestFixtures.threeRecommendationRequests,
+      testIdPrefix: customTestId,
+    });
 
     expect(
       screen.getByTestId(`${customTestId}-cell-row-0-col-requesterEmail`),
     ).toHaveTextContent("student1@ucsb.edu");
+  });
+
+  test("shows edit and delete buttons for admin users", () => {
+    renderTable({
+      recommendationRequests:
+        recommendationRequestFixtures.threeRecommendationRequests,
+      currentUser: currentUserFixtures.adminUser,
+    });
+
+    expect(screen.getByTestId(`${testId}-header-Edit`)).toHaveTextContent(
+      "Edit",
+    );
+    expect(screen.getByTestId(`${testId}-header-Delete`)).toHaveTextContent(
+      "Delete",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).toHaveClass("btn-primary");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).toHaveClass("btn-danger");
+  });
+
+  test("edit button navigates to edit page", () => {
+    renderTable({
+      recommendationRequests:
+        recommendationRequestFixtures.threeRecommendationRequests,
+      currentUser: currentUserFixtures.adminUser,
+    });
+
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/recommendationrequest/edit/1");
   });
 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 import axios from "axios";
@@ -8,10 +8,35 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 describe("RecommendationRequestIndexPage tests", () => {
   const h = React.createElement;
   const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "RecommendationRequestTable";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -19,6 +44,17 @@ describe("RecommendationRequestIndexPage tests", () => {
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
@@ -35,25 +71,133 @@ describe("RecommendationRequestIndexPage tests", () => {
     );
   };
 
-  test("renders expected content", async () => {
-    setupUserOnly();
+  test("renders with Create button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/RecommendationRequest/all").reply(200, []);
 
     renderPage();
 
-    await screen.findByText("Index page not yet implemented");
+    await screen.findByText("Create RecommendationRequest");
+    const button = screen.getByText("Create RecommendationRequest");
+    expect(button).toHaveAttribute("href", "/recommendationrequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+    expect(button).toHaveClass("btn-primary");
+    expect(screen.getByText("RecommendationRequests")).toBeInTheDocument();
+    expect(
+      screen.getByText("RecommendationRequests").closest(".pt-2"),
+    ).toHaveClass("pt-2");
+  });
+
+  test("renders three recommendation requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/RecommendationRequest/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
 
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Create")).toHaveAttribute(
-      "href",
-      "/recommendationrequest/create",
+      screen.queryByText("Create RecommendationRequest"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("student1@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-professorEmail`),
+    ).toHaveTextContent("professor1@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-explanation`),
+    ).toHaveTextContent("Request for a graduate school recommendation letter");
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    axiosMock.onGet("/api/RecommendationRequest/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/RecommendationRequest/all",
     );
-    expect(screen.getByText("Edit")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toHaveAttribute(
-      "href",
-      "/recommendationrequest/edit/1",
+    restoreConsole();
+  });
+
+  test("admin can navigate to edit page", async () => {
+    setupAdminUser();
+    axiosMock
+      .onGet("/api/RecommendationRequest/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+
+    renderPage();
+
+    const editButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
     );
+    fireEvent.click(editButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/recommendationrequest/edit/1");
+  });
+
+  test("admin can delete recommendation request", async () => {
+    setupAdminUser();
+    axiosMock
+      .onGet("/api/RecommendationRequest/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+    axiosMock
+      .onDelete("/api/RecommendationRequest")
+      .reply(200, "RecommendationRequest with id 1 was deleted");
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "RecommendationRequest with id 1 was deleted",
+      );
+    });
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/RecommendationRequest");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(4);
+    });
   });
 });


### PR DESCRIPTION
Adds RecommendationRequest index page with table, create/edit/delete controls, tests, and Storybook story.

Closes #26

Testing:
1. Navigate to /recommendationrequest
2. Confirm table data appears
3. As admin, confirm Create, Edit, and Delete buttons appear
4. Confirm Delete removes a record and refreshes the table
5. As regular user, confirm buttons are hidden
<img width="1512" height="830" alt="image" src="https://github.com/user-attachments/assets/0986e774-abe8-46a7-b41b-c56291c3eb6d" />
https://69f2f3fdc277d896027e091a-oqxfojgqkk.chromatic.com/?path=/story/components-helprequests-helprequestform--create