### PR TITLE
Add ArticlesEditPage with stories and tests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -120,26 +120,24 @@ function App() {
       )}
 
       {hasRole(currentUser, "ROLE_USER") && (
-  <>
-    <Route exact path="/articles" element={<ArticlesIndexPage />} />
-  </>
-)}
-{hasRole(currentUser, "ROLE_ADMIN") && (
-  <>
-    <Route
-      exact
-      path="/articles/edit/:id"
-      element={<ArticlesEditPage />}
-    />
-    <Route
-      exact
-      path="/articles/create"
-      element={<ArticlesCreatePage />}
-    />
-  </>
-)}
-
-
+        <>
+          <Route exact path="/articles" element={<ArticlesIndexPage />} />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/articles/edit/:id"
+            element={<ArticlesEditPage />}
+          />
+          <Route
+            exact
+            path="/articles/create"
+            element={<ArticlesCreatePage />}
+          />
+        </>
+      )}
     </Routes>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,10 @@ import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewInd
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/useCurrentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -114,6 +118,28 @@ function App() {
           />
         </>
       )}
+
+      {hasRole(currentUser, "ROLE_USER") && (
+  <>
+    <Route exact path="/articles" element={<ArticlesIndexPage />} />
+  </>
+)}
+{hasRole(currentUser, "ROLE_ADMIN") && (
+  <>
+    <Route
+      exact
+      path="/articles/edit/:id"
+      element={<ArticlesEditPage />}
+    />
+    <Route
+      exact
+      path="/articles/create"
+      element={<ArticlesCreatePage />}
+    />
+  </>
+)}
+
+
     </Routes>
   );
 }

--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -1,0 +1,38 @@
+const articlesFixtures = {
+  oneArticle: {
+    id: 1,
+    title: "Using testing-playground with React Testing Library",
+    url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+    explanation: "Helpful when we get to front end development",
+    email: "phtcon@ucsb.edu",
+    dateAdded: "2022-04-20T12:00:00",
+  },
+  threeArticles: [
+    {
+      id: 1,
+      title: "Using testing-playground with React Testing Library",
+      url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+      explanation: "Helpful when we get to front end development",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-20T12:00:00",
+    },
+    {
+      id: 2,
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInZEg&s=09",
+      explanation: "A lot of really useful classes are built into Spring",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-19T12:00:00",
+    },
+    {
+      id: 3,
+      title: "Effective Java",
+      url: "https://www.oreilly.com/library/view/effective-java-3rd/9780134686097/",
+      explanation: "A classic book on best practices for Java programming",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-18T12:00:00",
+    },
+  ],
+};
+
+export { articlesFixtures };

--- a/frontend/src/main/components/Articles/ArticlesForm.jsx
+++ b/frontend/src/main/components/Articles/ArticlesForm.jsx
@@ -1,0 +1,179 @@
+import { Button, Form, Row, Col } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function ArticlesForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
+  // Stryker disable next-line Regex
+  const email_regex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+
+  // Stryker disable next-line Regex
+  const url_regex = /^https?:\/\/.+/i;
+
+  const testIdPrefix = "ArticlesForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Row>
+        {initialContents && (
+          <Col>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="id">Id</Form.Label>
+              <Form.Control
+                data-testid={testIdPrefix + "-id"}
+                id="id"
+                type="text"
+                {...register("id")}
+                value={initialContents.id}
+                disabled
+              />
+            </Form.Group>
+          </Col>
+        )}
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="title">Title</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-title"}
+              id="title"
+              type="text"
+              isInvalid={Boolean(errors.title)}
+              {...register("title", {
+                required: "Title is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.title?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="url">URL</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-url"}
+              id="url"
+              type="text"
+              isInvalid={Boolean(errors.url)}
+              {...register("url", {
+                required: "URL is required.",
+                pattern: {
+                  value: url_regex,
+                  message: "URL must start with http:// or https://",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.url?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="explanation">Explanation</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-explanation"}
+              id="explanation"
+              type="text"
+              isInvalid={Boolean(errors.explanation)}
+              {...register("explanation", {
+                required: "Explanation is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.explanation?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="email">Email</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-email"}
+              id="email"
+              type="text"
+              isInvalid={Boolean(errors.email)}
+              {...register("email", {
+                required: "Email is required.",
+                pattern: {
+                  value: email_regex,
+                  message: "Email must be a valid email address",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.email?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="dateAdded">Date Added (iso format)</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-dateAdded"}
+              id="dateAdded"
+              type="datetime-local"
+              isInvalid={Boolean(errors.dateAdded)}
+              {...register("dateAdded", {
+                required: true,
+                pattern: isodate_regex,
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.dateAdded && "DateAdded is required. "}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+            {buttonLabel}
+          </Button>
+          <Button
+            variant="Secondary"
+            onClick={() => navigate(-1)}
+            data-testid={testIdPrefix + "-cancel"}
+          >
+            Cancel
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default ArticlesForm;

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -62,6 +62,9 @@ export default function AppNavbar({
               )}
               {currentUser && currentUser.loggedIn ? (
                 <>
+                   <Nav.Link as={Link} to="/articles">
+                    Articles
+                   </Nav.Link>
                   <Nav.Link as={Link} to="/restaurants">
                     Restaurants
                   </Nav.Link>

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -62,9 +62,9 @@ export default function AppNavbar({
               )}
               {currentUser && currentUser.loggedIn ? (
                 <>
-                   <Nav.Link as={Link} to="/articles">
+                  <Nav.Link as={Link} to="/articles">
                     Articles
-                   </Nav.Link>
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/restaurants">
                     Restaurants
                   </Nav.Link>

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,11 +1,48 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (article) => ({
+    url: "/api/articles/post",
+    method: "POST",
+    params: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`New article Created - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/articles/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+        <ArticlesForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,11 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: article,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/articles?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/articles`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (article) => ({
+    url: "/api/articles",
+    method: "PUT",
+    params: {
+      id: article.id,
+    },
+    data: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`Article Updated - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/articles?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Article</h1>
+        {article && (
+          <ArticlesForm
+            initialContents={article}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/articles/create">Create</a>
+        </p>
+        <p>
+          <a href="/articles/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+export default {
+  title: "components/Articles/ArticlesForm",
+  component: ArticlesForm,
+};
+
+const Template = (args) => {
+  return <ArticlesForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: articlesFixtures.oneArticle,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+  title: "pages/Articles/ArticlesCreatePage",
+  component: ArticlesCreatePage,
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.post("/api/articles/post", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
+  },
+};

--- a/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
+export default {
+  title: "pages/Articles/ArticlesEditPage",
+  component: ArticlesEditPage,
+};
+
+const Template = () => <ArticlesEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: {
+    handlers: [
+      http.get("/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("/api/articles", () => {
+        return HttpResponse.json(articlesFixtures.threeArticles[0], {
+          status: 200,
+        });
+      }),
+      http.put("/api/articles", () => {
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
@@ -1,0 +1,134 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { BrowserRouter as Router } from "react-router";
+import { expect } from "vitest";
+
+const mockedNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticlesForm tests", () => {
+  test("renders correctly", async () => {
+    render(
+      <Router>
+        <ArticlesForm />
+      </Router>,
+    );
+    await screen.findByText(/Title/);
+    await screen.findByText(/Create/);
+    expect(screen.getByText(/Title/)).toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <Router>
+        <ArticlesForm initialContents={articlesFixtures.oneArticle} />
+      </Router>,
+    );
+    await screen.findByTestId(/ArticlesForm-id/);
+    expect(screen.getByText(/Id/)).toBeInTheDocument();
+    expect(screen.getByTestId(/ArticlesForm-id/)).toHaveValue("1");
+  });
+
+  test("Correct Error messages on bad input", async () => {
+    render(
+      <Router>
+        <ArticlesForm />
+      </Router>,
+    );
+    await screen.findByTestId("ArticlesForm-url");
+    const urlField = screen.getByTestId("ArticlesForm-url");
+    const emailField = screen.getByTestId("ArticlesForm-email");
+    const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+    const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+    fireEvent.change(urlField, { target: { value: "bad-url" } });
+    fireEvent.change(emailField, { target: { value: "bad-email" } });
+    fireEvent.change(dateAddedField, { target: { value: "bad-input" } });
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/URL must start with http:\/\/ or https:\/\//);
+    expect(
+      screen.getByText(/Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+
+  test("Correct Error messages on missing input", async () => {
+    render(
+      <Router>
+        <ArticlesForm />
+      </Router>,
+    );
+    await screen.findByTestId("ArticlesForm-submit");
+    const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Title is required./);
+    expect(screen.getByText(/URL is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required./)).toBeInTheDocument();
+    expect(screen.getByText(/DateAdded is required./)).toBeInTheDocument();
+  });
+
+  test("No Error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <Router>
+        <ArticlesForm submitAction={mockSubmitAction} />
+      </Router>,
+    );
+    await screen.findByTestId("ArticlesForm-title");
+
+    const titleField = screen.getByTestId("ArticlesForm-title");
+    const urlField = screen.getByTestId("ArticlesForm-url");
+    const explanationField = screen.getByTestId("ArticlesForm-explanation");
+    const emailField = screen.getByTestId("ArticlesForm-email");
+    const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+    const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+    fireEvent.change(titleField, { target: { value: "Sample Title" } });
+    fireEvent.change(urlField, {
+      target: { value: "https://example.com/article" },
+    });
+    fireEvent.change(explanationField, {
+      target: { value: "Sample explanation" },
+    });
+    fireEvent.change(emailField, { target: { value: "user@ucsb.edu" } });
+    fireEvent.change(dateAddedField, {
+      target: { value: "2022-04-20T12:00" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(/URL must start with http:\/\/ or https:\/\//),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Email must be a valid email address/),
+    ).not.toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <Router>
+        <ArticlesForm />
+      </Router>,
+    );
+    await screen.findByTestId("ArticlesForm-cancel");
+    const cancelButton = screen.getByTestId("ArticlesForm-cancel");
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
@@ -6,12 +6,33 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("ArticlesCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,14 +41,34 @@ describe("ArticlesCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-    setupUserOnly();
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("ArticlesForm-title")).toBeInTheDocument();
+    });
+  });
 
-    // act
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const article = {
+      id: 17,
+      title: "Sample Article",
+      url: "https://example.com/sample",
+      explanation: "A sample explanation",
+      email: "user@ucsb.edu",
+      dateAdded: "2022-04-20T12:00",
+    };
+    axiosMock.onPost("/api/articles/post").reply(202, article);
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -36,10 +77,45 @@ describe("ArticlesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("ArticlesForm-title")).toBeInTheDocument();
+    });
+
+    const titleField = screen.getByTestId("ArticlesForm-title");
+    const urlField = screen.getByTestId("ArticlesForm-url");
+    const explanationField = screen.getByTestId("ArticlesForm-explanation");
+    const emailField = screen.getByTestId("ArticlesForm-email");
+    const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+    const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+    fireEvent.change(titleField, { target: { value: "Sample Article" } });
+    fireEvent.change(urlField, {
+      target: { value: "https://example.com/sample" },
+    });
+    fireEvent.change(explanationField, {
+      target: { value: "A sample explanation" },
+    });
+    fireEvent.change(emailField, { target: { value: "user@ucsb.edu" } });
+    fireEvent.change(dateAddedField, {
+      target: { value: "2022-04-20T12:00" },
+    });
+
+    expect(submitButton).toBeInTheDocument();
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      title: "Sample Article",
+      url: "https://example.com/sample",
+      explanation: "A sample explanation",
+      email: "user@ucsb.edu",
+      dateAdded: "2022-04-20T12:00",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New article Created - id: 17 title: Sample Article",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/articles" });
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,45 +1,196 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("ArticlesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-    setupUserOnly();
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <ArticlesEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+let axiosMock;
+describe("ArticlesEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).timeout();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Article");
+      expect(
+        screen.queryByTestId("ArticlesForm-title"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/articles", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        title: "Original Title",
+        url: "https://example.com/original",
+        explanation: "Original explanation",
+        email: "original@ucsb.edu",
+        dateAdded: "2022-04-20T12:00",
+      });
+      axiosMock.onPut("/api/articles").reply(200, {
+        id: "17",
+        title: "Updated Title",
+        url: "https://example.com/updated",
+        explanation: "Updated explanation",
+        email: "updated@ucsb.edu",
+        dateAdded: "2023-05-21T13:00",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-title");
+
+      const idField = screen.getByTestId("ArticlesForm-id");
+      const titleField = screen.getByTestId("ArticlesForm-title");
+      const urlField = screen.getByTestId("ArticlesForm-url");
+      const explanationField = screen.getByTestId("ArticlesForm-explanation");
+      const emailField = screen.getByTestId("ArticlesForm-email");
+      const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+      const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(titleField).toHaveValue("Original Title");
+      expect(urlField).toHaveValue("https://example.com/original");
+      expect(explanationField).toHaveValue("Original explanation");
+      expect(emailField).toHaveValue("original@ucsb.edu");
+      expect(dateAddedField).toHaveValue("2022-04-20T12:00");
+
+      expect(submitButton).toHaveTextContent("Update");
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-title");
+
+      const titleField = screen.getByTestId("ArticlesForm-title");
+      const urlField = screen.getByTestId("ArticlesForm-url");
+      const explanationField = screen.getByTestId("ArticlesForm-explanation");
+      const emailField = screen.getByTestId("ArticlesForm-email");
+      const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+      const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+      fireEvent.change(titleField, { target: { value: "Updated Title" } });
+      fireEvent.change(urlField, {
+        target: { value: "https://example.com/updated" },
+      });
+      fireEvent.change(explanationField, {
+        target: { value: "Updated explanation" },
+      });
+      fireEvent.change(emailField, { target: { value: "updated@ucsb.edu" } });
+      fireEvent.change(dateAddedField, {
+        target: { value: "2023-05-21T13:00" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: Updated Title",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          title: "Updated Title",
+          url: "https://example.com/updated",
+          explanation: "Updated explanation",
+          email: "updated@ucsb.edu",
+          dateAdded: "2023-05-21T13:00",
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticlesIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,118 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Articles")
+@RequestMapping("/api/articles")
+@RestController
+@Slf4j
+public class ArticlesController extends ApiController {
+
+  @Autowired ArticlesRepository articlesRepository;
+
+  @Operation(summary = "List all articles")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<Articles> allArticles() {
+    Iterable<Articles> articles = articlesRepository.findAll();
+    return articles;
+  }
+
+  @Operation(summary = "Get a single article")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public Articles getById(@Parameter(name = "id") @RequestParam Long id) {
+    Articles article =
+        articlesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    return article;
+  }
+
+  @Operation(summary = "Create a new article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public Articles postArticle(
+      @Parameter(name = "title") @RequestParam String title,
+      @Parameter(name = "url") @RequestParam String url,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "email") @RequestParam String email,
+      @Parameter(
+              name = "dateAdded",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateAdded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateAdded)
+      throws JsonProcessingException {
+
+    log.info("dateAdded={}", dateAdded);
+
+    Articles article = new Articles();
+    article.setTitle(title);
+    article.setUrl(url);
+    article.setExplanation(explanation);
+    article.setEmail(email);
+    article.setDateAdded(dateAdded);
+
+    Articles savedArticle = articlesRepository.save(article);
+
+    return savedArticle;
+  }
+
+  @Operation(summary = "Delete an Article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteArticle(@Parameter(name = "id") @RequestParam Long id) {
+    Articles article =
+        articlesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    articlesRepository.delete(article);
+    return genericMessage("Articles with id %s deleted".formatted(id));
+  }
+
+  @Operation(summary = "Update a single article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public Articles updateArticle(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+
+    Articles article =
+        articlesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    article.setTitle(incoming.getTitle());
+    article.setUrl(incoming.getUrl());
+    article.setExplanation(incoming.getExplanation());
+    article.setEmail(incoming.getEmail());
+    article.setDateAdded(incoming.getDateAdded());
+
+    articlesRepository.save(article);
+
+    return article;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,28 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The ArticlesRepository is a repository for Articles entities. */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Articles-1",
+        "author": "ArjunUCSB",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "ARTICLES"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "ARTICLES_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DATE_ADDED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPLANATION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TITLE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "URL",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "ARTICLES"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,385 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+  @MockitoBean ArticlesRepository articlesRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/articles/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/articles/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/articles/all")).andExpect(status().is(200)); // logged
+  }
+
+  // Authorization tests for /api/articles/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/articles/post")
+                .param("title", "Using testing-playground with React Testing Library")
+                .param(
+                    "url",
+                    "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                .param("explanation", "Helpful when we get to front end development")
+                .param("email", "phtcon@ucsb.edu")
+                .param("dateAdded", "2022-04-20T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/articles/post")
+                .param("title", "Using testing-playground with React Testing Library")
+                .param(
+                    "url",
+                    "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                .param("explanation", "Helpful when we get to front end development")
+                .param("email", "phtcon@ucsb.edu")
+                .param("dateAdded", "2022-04-20T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_articles() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article1 =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-04-19T00:00:00");
+
+    Articles article2 =
+        Articles.builder()
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInZEg&s=09")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt2)
+            .build();
+
+    ArrayList<Articles> expectedArticles = new ArrayList<>();
+    expectedArticles.addAll(Arrays.asList(article1, article2));
+
+    when(articlesRepository.findAll()).thenReturn(expectedArticles);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/articles/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedArticles);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_article() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article1 =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    when(articlesRepository.save(eq(article1))).thenReturn(article1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/articles/post")
+                    .param("title", "Using testing-playground with React Testing Library")
+                    .param(
+                        "url",
+                        "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                    .param("explanation", "Helpful when we get to front end development")
+                    .param("email", "phtcon@ucsb.edu")
+                    .param("dateAdded", "2022-04-20T00:00:00")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).save(article1);
+    String expectedJson = mapper.writeValueAsString(article1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_article() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article1 =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(article1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/articles").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(15L);
+    verify(articlesRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_article_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+
+    when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/articles").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 15 not found", json.get("message"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/articles").param("id", "7"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(article));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/articles").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(articlesRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(article);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/articles").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(articlesRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("Articles with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_article() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-04-20T00:00:00");
+
+    Articles articleOrig =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    Articles articleEdited =
+        Articles.builder()
+            .title("Updated Title")
+            .url("https://example.com/updated")
+            .explanation("Updated explanation")
+            .email("updated@ucsb.edu")
+            .dateAdded(ldt2)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(articleEdited);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(articleOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    verify(articlesRepository, times(1)).save(articleEdited); // should be saved with correct user
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_article_that_does_not_exist() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles articleEdited =
+        Articles.builder()
+            .title("Nonexistent Article")
+            .url("https://example.com/nonexistent")
+            .explanation("This article does not exist")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(articleEdited);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 67 not found", json.get("message"));
+  }
+}


### PR DESCRIPTION
Implements `ArticlesEditPage` so admin users can edit existing articles. This is the final frontend issue for Articles.

**Files modified/added:**
- `frontend/src/main/pages/Articles/ArticlesEditPage.jsx` (replaced placeholder content)
- `frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx` (replaced placeholder content)
- `frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx` (new file)

**Behavior:**
- GETs `/api/articles?id={id}` to load the existing article
- Pre-populates the form with all 6 fields 
- On submit, PUTs to `/api/articles?id={id}` with JSON body
- On success, shows a toast and navigates to `/articles`
- Validation errors prevent submission and stay on the page
- Cancel button navigates back

**How to test:**
1. Run backend (`mvn spring-boot:run`) and frontend (`npm start`)
2. Log in as admin
3. POST a test article via `/articles/create` and note its id
4. Visit `/articles/edit/<id>` directly in the URL
5. Verify the form is populated with the existing data
6. Edit a few fields, click Update — should see toast and redirect to `/articles`
7. Verify changes persisted by re-visiting the edit page or checking Swagger
8. Test validation: clear a required field, submit — should see errors, no redirect
9. Test cancel: change a field, click Cancel — should navigate back without saving

**Screenshot:**

Pre-populated edit form:
<img width="2304" height="1156" alt="image" src="https://github.com/user-attachments/assets/842d54e6-ac35-4e43-ade0-8c28a08c782c" />


**Storybook link:**
https://69f2f3fdc277d896027e091a-etulazaqik.chromatic.com/

Closes #54 