### PR TITLE
implement MenuItemReview edit page with tests and Storybook

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.jsx
@@ -1,11 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function MenuItemReviewEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: review,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/MenuItemReview?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/MenuItemReview`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (incoming) => ({
+    url: "/api/MenuItemReview",
+    method: "PUT",
+    params: {
+      id: incoming.id,
+    },
+    data: {
+      itemId: incoming.itemId,
+      reviewerEmail: incoming.reviewerEmail,
+      stars: incoming.stars,
+      dateReviewed: incoming.dateReviewed,
+      comments: incoming.comments,
+    },
+  });
+
+  const onSuccess = (saved) => {
+    toast(`MenuItemReview Updated - id: ${saved.id} itemId: ${saved.itemId}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/MenuItemReview?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Menu Item Review</h1>
+        {review && (
+          <MenuItemReviewForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={review}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { MemoryRouter, Routes, Route } from "react-router";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
+const reviewForEdit = {
+  id: 17,
+  itemId: 101,
+  reviewerEmail: "cgaucho@ucsb.edu",
+  stars: 5,
+  dateReviewed: "2022-01-02T12:00:00",
+  comments: "Best pizza at Carrillo",
+};
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewEditPage",
+  component: MenuItemReviewEditPage,
+};
+
+const Template = () => (
+  <MemoryRouter initialEntries={["/menuitemreview/edit/17"]}>
+    <Routes>
+      <Route
+        path="/menuitemreview/edit/:id"
+        element={<MenuItemReviewEditPage storybook={true} />}
+      />
+    </Routes>
+  </MemoryRouter>
+);
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: {
+    handlers: [
+      http.get("*/api/currentUser", () => {
+        return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+          status: 200,
+        });
+      }),
+      http.get("*/api/systemInfo", () => {
+        return HttpResponse.json(systemInfoFixtures.showingNeither, {
+          status: 200,
+        });
+      }),
+      http.get("*/api/MenuItemReview", () => {
+        return HttpResponse.json(reviewForEdit, {
+          status: 200,
+        });
+      }),
+      http.put("*/api/MenuItemReview", () => {
+        return HttpResponse.json(
+          {
+            id: 17,
+            itemId: 102,
+            reviewerEmail: "cgaucho@ucsb.edu",
+            stars: 4,
+            dateReviewed: "2022-01-02T12:00:00",
+            comments: "Updated comment",
+          },
+          { status: 200 },
+        );
+      }),
+    ],
+  },
+};

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.jsx
@@ -1,43 +1,249 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("MenuItemReviewEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+const mockNavigate = vi.fn();
+const mockNavigateBack = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    useNavigate: () => mockNavigateBack,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <MenuItemReviewEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+let axiosMock;
+describe("MenuItemReviewEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/MenuItemReview", { params: { id: 17 } }).timeout();
+    });
 
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      mockNavigateBack.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Menu Item Review");
+      expect(
+        screen.queryByTestId("MenuItemReviewForm-itemId"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/MenuItemReview", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          itemId: 101,
+          reviewerEmail: "cgaucho@ucsb.edu",
+          stars: 5,
+          dateReviewed: "2022-01-02T12:00:00",
+          comments: "Best pizza at Carrillo",
+        });
+      axiosMock.onPut("/api/MenuItemReview").reply(200, {
+        id: 17,
+        itemId: 102,
+        reviewerEmail: "cgaucho@ucsb.edu",
+        stars: 4,
+        dateReviewed: "2022-01-03T10:00:00",
+        comments: "Updated notes",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      mockNavigateBack.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const idField = screen.getByTestId("MenuItemReviewForm-id");
+      const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+      const emailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+      const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+      const dateField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+      const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(itemIdField).toHaveValue("101");
+      expect(emailField).toHaveValue("cgaucho@ucsb.edu");
+      expect(starsField).toHaveValue(5);
+      expect(commentsField).toHaveValue("Best pizza at Carrillo");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(itemIdField, { target: { value: "102" } });
+      fireEvent.change(starsField, { target: { value: "4" } });
+      fireEvent.change(dateField, { target: { value: "2022-01-03T10:00" } });
+      fireEvent.change(commentsField, { target: { value: "Updated notes" } });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "MenuItemReview Updated - id: 17 itemId: 102",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          itemId: "102",
+          reviewerEmail: "cgaucho@ucsb.edu",
+          stars: "4",
+          dateReviewed: "2022-01-03T10:00",
+          comments: "Updated notes",
+        }),
+      );
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-id");
+
+      const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+      const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      fireEvent.change(itemIdField, { target: { value: "102" } });
+      fireEvent.change(screen.getByTestId("MenuItemReviewForm-stars"), {
+        target: { value: "4" },
+      });
+      fireEvent.change(screen.getByTestId("MenuItemReviewForm-dateReviewed"), {
+        target: { value: "2022-01-03T10:00" },
+      });
+      fireEvent.change(screen.getByTestId("MenuItemReviewForm-comments"), {
+        target: { value: "Updated notes" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "MenuItemReview Updated - id: 17 itemId: 102",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview" });
+    });
+
+    test("does not PUT when form data is invalid", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-comments");
+
+      fireEvent.change(screen.getByTestId("MenuItemReviewForm-comments"), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByTestId("MenuItemReviewForm-submit"));
+
+      expect(
+        await screen.findByText(/Comments are required./),
+      ).toBeInTheDocument();
+      expect(axiosMock.history.put.length).toBe(0);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    test("Cancel navigates back like the browser back button", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <MenuItemReviewEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("MenuItemReviewForm-cancel");
+
+      fireEvent.click(screen.getByTestId("MenuItemReviewForm-cancel"));
+
+      expect(mockNavigateBack).toHaveBeenCalledWith(-1);
+      expect(axiosMock.history.put.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
- Load review via GET /api/MenuItemReview?id=; PUT with JSON body per backend
- Navigate to index on success; invalid form shows MenuItemReviewForm errors
- Cancel uses navigate(-1); Storybook uses nested router + */api MSW handlers
closes #36 

Storybook URL: https://69f2f3fdc277d896027e091a-tlrxvffygl.chromatic.com/
