### PR TITLE
Add ArticleIT integration test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/ArticleIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/ArticleIT.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ArticleIT {
+
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired ArticlesRepository articlesRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-04-20T12:00:00");
+    Articles article =
+        Articles.builder()
+            .title("Sample Article")
+            .url("https://example.com/sample")
+            .explanation("Sample explanation")
+            .email("user@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+    articlesRepository.save(article);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/articles?id=1")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(article);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_article() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-04-20T12:00:00");
+    Articles article1 =
+        Articles.builder()
+            .id(1L)
+            .title("Sample Article")
+            .url("https://example.com/sample")
+            .explanation("Sample explanation")
+            .email("user@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/articles/post?title=Sample Article&url=https://example.com/sample&explanation=Sample explanation&email=user@ucsb.edu&dateAdded=2022-04-20T12:00:00")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(article1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Adds `ArticleIT` integration test for the Articles controller, modeled after `RestaurantIT`.

**Tests included:**
- `test_that_logged_in_user_can_get_by_id_when_the_id_exists` — verifies `GET /api/articles?id={id}` returns the saved article
- `an_admin_user_can_post_a_new_article` — verifies `POST /api/articles/post` creates a new article in the real database

Unlike unit tests, these use the real `ArticlesRepository` against an H2 test database (configured via `@ActiveProfiles("integration")`).

**Verified locally:**


Both tests pass.

Closes #139 